### PR TITLE
spring-bootified sender client configuration module

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 07 18:08:48 EEST 2015
+#Thu Nov 05 14:56:24 EET 2015
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-all.zip

--- a/scm-message-sender-client-starter/build.gradle
+++ b/scm-message-sender-client-starter/build.gradle
@@ -1,0 +1,9 @@
+description = 'SCM Message Sender Client SpringBoot Starter'
+
+apply from: "https://raw.githubusercontent.com/ametiste-oss/ametiste-bintray-gradle/master/bintray.gradle"
+apply plugin: 'groovy'
+
+dependencies {
+    compile project(":scm-message-sender-client")
+    compile libraries.springBoot
+}

--- a/scm-message-sender-client-starter/src/main/resources/META-INF/spring.factories
+++ b/scm-message-sender-client-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+	org.ametiste.scm.messaging.sender.client.config.StartupEventSendConfiguration

--- a/settings.gradle
+++ b/settings.gradle
@@ -5,5 +5,6 @@ include 'scm-messages-http'
 include 'scm-message-receiver'
 include 'scm-message-sender'
 include 'scm-message-sender-client'
+include 'scm-message-sender-client-starter'
 include 'scm-messages-mongo'
 


### PR DESCRIPTION
Now sender-client can be enabled just placing starter into classpath:

```
compile("org.ametiste.scm:scm-message-sender-client-starter:${ameScmVersion}")
```

Just to avoid of boilerplate configuration import

``` java
@Configuration
@Import(StartupEventSendConfiguration.class)
public class ApplicationContext() {
}
```

And to be close to spring-:boot: upstream design concepts.
